### PR TITLE
Add HEDGEHOG

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [CDK (Chemistry Development Kit)](https://cdk.github.io/) – Java library for structural cheminformatics.
 - [DeepChem](https://deepchem.io/) – Machine learning toolkit for chemistry and drug discovery.
 - [KNIME Analytics Platform](https://www.knime.com/) – Visual workflow tool with strong cheminformatics extensions.
+- [HEDGEHOG](https://github.com/LigandPro/hedgehog) – Stage-based evaluation pipeline for generative molecular design, docking, pose validation, and reporting.
 
 ## Quantum Chemistry
 


### PR DESCRIPTION
## Summary
- Add HEDGEHOG to Cheminformatics & Molecular Modeling.

## Validation
- Ran `git diff --check`.